### PR TITLE
update floors, add run_constrained entries for optional dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @aldanor @synapticarbors @xhochy
+* @aldanor @jameslamb @synapticarbors @xhochy

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ Feedstock Maintainers
 =====================
 
 * [@aldanor](https://github.com/aldanor/)
+* [@jameslamb](https://github.com/jameslamb/)
 * [@synapticarbors](https://github.com/synapticarbors/)
 * [@xhochy](https://github.com/xhochy/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
 
 requirements:
   build:
-    - python >=3.7                           # [build_platform != target_platform]
+    - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - cmake >=3.18
     - make
@@ -24,12 +24,12 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - scikit-build-core >=0.9.3
-    - python >=3.7
+    - python
     - pip
     - llvm-openmp  # [osx]
     - libgomp  # [linux]
   run:
-    - python >=3.7
+    - python
     - numpy >=1.17.0
     - scipy
   # optional dependencies from [project.optional-dependencies]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,36 +10,43 @@ source:
   sha256: 9e8a7640911481134e60987d5d1e1cd157f430c3b4b38de8d36fc55c302bc299
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install .
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
+    - python >=3.7                           # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cmake >=3.8
+    - cmake >=3.18
     - make
     - {{ compiler('c') }}
     - {{ stdlib("c") }}
     - {{ compiler('cxx') }}
   host:
     - scikit-build-core >=0.9.3
-    - python
+    - python >=3.7
     - pip
-    - setuptools
     - llvm-openmp  # [osx]
     - libgomp  # [linux]
   run:
-    - python
-    - numpy
+    - python >=3.7
+    - numpy >=1.17.0
     - scipy
+  # optional dependencies from [project.optional-dependencies]
+  # at https://github.com/microsoft/LightGBM/blob/master/python-package/pyproject.toml
+  run_constrained:
+    - cffi >=1.15.1
+    - dask >=2.0.0
+    - pandas >=0.24.0
+    - pyarrow >=6.0.1
+    - scikit-learn !=0.22.0
 
 test:
   imports:
     - lightgbm
   requires:
     - pip
-    - scikit-learn !=0.22.0
+    - scikit-learn
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,3 +68,4 @@ extra:
     - synapticarbors
     - aldanor
     - xhochy
+    - jameslamb


### PR DESCRIPTION
👋🏻 hi, I'm one of the maintainers of LightGBM.

In the most recent (v4.4.0) release, the Python package there picked up a runtime floor on `numpy` (https://github.com/microsoft/LightGBM/pull/6468). I came here to add that floor to the `conda-forge` package, and found a few other opportunities to align the pins here with the way `lightgbm` is packaged for PyPI.

This proposes:

* adding floors on `cmake` and `numpy`
* removing unnecessary host dependency on `setuptools`
* adding `run_constrained:` floors for `lightgbm`'s optional dependencies

For reference, these all mirror the dependencies in https://github.com/microsoft/LightGBM/blob/master/python-package/pyproject.toml.

Thanks for your time and consideration.

### Checklist

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
