### PR TITLE
CUDA builds should depend on __cuda

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - boost_shared.diff
 
 build:
-  number: 2
+  number: 3
   string: cuda_py{{ PY_VER }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
   string: cpu_py{{ PY_VER }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}   # [cuda_compiler_version == "None"]
   # CUDA is not supported in windows
@@ -52,6 +52,7 @@ requirements:
     - python
     - numpy >=1.17.0
     - scipy
+    - __cuda                      # [cuda_compiler != "None"]
   # optional dependencies from [project.optional-dependencies]
   # at https://github.com/microsoft/LightGBM/blob/master/python-package/pyproject.toml
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - python
     - numpy >=1.17.0
     - scipy
-    - __cuda                      # [cuda_compiler != "None"]
+    - __cuda                      # [cuda_compiler_version != "None"]
   # optional dependencies from [project.optional-dependencies]
   # at https://github.com/microsoft/LightGBM/blob/master/python-package/pyproject.toml
   run_constrained:


### PR DESCRIPTION
Addresses https://github.com/conda-forge/lightgbm-feedstock/issues/57

In most cases, CUDA build are downweighted because they have more dependencies but in this case the OpenCL dependencies larger in the number of packages.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
