### PR TITLE
Add VERSION.txt back to Python package

### DIFF
--- a/recipe/install-python.bat
+++ b/recipe/install-python.bat
@@ -1,1 +1,2 @@
 %PYTHON% -m pip install . -vv --no-deps
+echo %PKG_VERSION% > %SP_DIR%/lightgbm/VERSION.txt

--- a/recipe/install-python.sh
+++ b/recipe/install-python.sh
@@ -1,1 +1,2 @@
 $PYTHON -m pip install . -vv --no-deps
+echo $PKG_VERSION > $SP_DIR/lightgbm/VERSION.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - use_precompiled.diff
 
 build:
-  number: 2
+  number: 3
   string: cuda_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
   string: cpu_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version == "None"]
   # CUDA is not supported in windows
@@ -86,12 +86,21 @@ outputs:
         - python_run_test.py
       imports:
         - lightgbm
+        - lightgbm.basic
+        - lightgbm.callback
+        - lightgbm.compat
+        - lightgbm.dask
+        - lightgbm.engine
+        - lightgbm.libpath
+        - lightgbm.plotting
+        - lightgbm.sklearn
       requires:
         - pip
         - scikit-learn
       commands:
         - pip check
         - python python_run_test.py
+        - python -c 'from lightgbm import __version__'
 
 about:
   home: https://github.com/microsoft/LightGBM

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -100,7 +100,7 @@ outputs:
       commands:
         - pip check
         - python python_run_test.py
-        - python -c 'from lightgbm import __version__'
+        - python -c "from lightgbm import __version__"
 
 about:
   home: https://github.com/microsoft/LightGBM


### PR DESCRIPTION
Closes #66 

I understand that there are better ways to convey / get a package's version number than having a VERSION.txt file in the wheel. But I think this was an unexpected side effect of #65 and should be fixed.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
