### PR TITLE
Add cuda version to build string

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,8 @@ source:
     - patches/0005-drop-arches-for-cuda13.patch
 
 build:
-  number: 4
-  string: cuda_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
+  number: 5
+  string: cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
   string: cpu_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version == "None"]
   # CUDA is not supported in windows
   skip: true  # [cuda_compiler_version != "None" and win]
@@ -61,7 +61,7 @@ outputs:
     script: install-python.sh
     build:
       noarch: python
-      string: cuda_py_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
+      string: cuda{{ cuda_compiler_version | replace('.', '') }}_py_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
       string: cpu_py_{{ PKG_BUILDNUM }}   # [cuda_compiler_version == "None"]
       # TODO: remove this when conda-build bug is fixed where `noarch` subpackages
       # when tested does not find dependencies from target_platform.


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This is needed to explicitly pin the builds to a specific cuda compiler version
