### PR TITLE
[skip ci] update LightGBM links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ About lightgbm-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/lightgbm-feedstock/blob/main/LICENSE.txt)
 
-Home: https://github.com/microsoft/LightGBM
+Home: https://github.com/lightgbm-org/LightGBM
 
 Package license: MIT
 
 Summary: LightGBM is a gradient boosting framework that uses tree based learning algorithms.
 
-Development: https://github.com/microsoft/LightGBM
+Development: https://github.com/lightgbm-org/LightGBM
 
 Documentation: https://lightgbm.readthedocs.io/en/v4.6.0/
 

--- a/recipe/patches/0002-use-precompiled.patch
+++ b/recipe/patches/0002-use-precompiled.patch
@@ -36,8 +36,8 @@ index fa281078..3e35059f 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -55,35 +55,11 @@ documentation = "https://lightgbm.readthedocs.io/en/latest/"
- repository = "https://github.com/microsoft/LightGBM.git"
- changelog = "https://github.com/microsoft/LightGBM/releases"
+ repository = "https://github.com/lightgbm-org/LightGBM.git"
+ changelog = "https://github.com/lightgbm-org/LightGBM/releases"
  
 -# start:build-system
  [build-system]

--- a/recipe/python_run_test.py
+++ b/recipe/python_run_test.py
@@ -4,7 +4,7 @@ A simple test for LightGBM based on scikit-learn.
 Tests are not shipped with the source distribution so we include a simple
 functional test here that is adapted from:
 
-    https://github.com/Microsoft/LightGBM/blob/master/tests/python_package_test/test_sklearn.py
+    https://github.com/lightgbm-org/LightGBM/blob/master/tests/python_package_test/test_sklearn.py
 
 """
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: cb1c59720eb569389c0ba74d14f52351b573af489f230032a1c9f314f8bab7fe
   patches:
     - patches/0001-boost-shared.patch
-    # Taken from https://github.com/microsoft/LightGBM/blob/v4.5.0/build-python.sh#L308-L316
+    # Taken from https://github.com/lightgbm-org/LightGBM/blob/v4.5.0/build-python.sh#L308-L316
     # except that we don't copy lib_lightgbm.so to SP_DIR
     - patches/0002-use-precompiled.patch
     # Compatibility fix for Boost 1.86
@@ -105,7 +105,7 @@ outputs:
           then:
             - __cuda
       # optional dependencies from [project.optional-dependencies]
-      # at https://github.com/microsoft/LightGBM/blob/master/python-package/pyproject.toml
+      # at https://github.com/lightgbm-org/LightGBM/blob/master/python-package/pyproject.toml
       run_constraints:
         - cffi >=1.15.1
         - dask >=2.0.0
@@ -139,7 +139,7 @@ outputs:
               - python ${{ python_min }}.*
 
 about:
-  homepage: https://github.com/microsoft/LightGBM
+  homepage: https://github.com/lightgbm-org/LightGBM
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -148,7 +148,7 @@ about:
   description: |
     A fast, distributed, high performance gradient boosting (GBDT, GBRT, GBM or MART) framework based on decision tree algorithms, used for ranking, classification and many other machine learning tasks.
   documentation: https://lightgbm.readthedocs.io/en/v${{ version }}/
-  repository: https://github.com/microsoft/LightGBM
+  repository: https://github.com/lightgbm-org/LightGBM
 
 extra:
   feedstock-name: lightgbm


### PR DESCRIPTION
LightGBM has moved out of `Microsoft/` to its own organization: https://github.com/lightgbm-org/LightGBM/issues/7187

This updates links in this project to reflect that.

Thanks for helping people use LightGBM!

## Notes for Reviewers

Putting `[skip ci]` + not bumping the build number... this doesn't require new builds. Just want to get these changes into the repo, they can go out with the next packages whenever there's a new build.

### Checklist

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.