### PR TITLE
Add CUDA variants (12.9, 13.1) for GPU-accelerated training

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+    - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr1/65e62e9

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr3/73950a5
+  - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr3/8d8835a

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-    - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr1/65e62e9

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+    - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr2/cbde43f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr3/73950a5

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-    - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr2/cbde43f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr3/940162d
+  - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr3/8b87510

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr3/8b87510

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr3/8d8835a
+  - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr3/940162d

--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,0 +1,4 @@
+anaconda_config_version: 1
+upstream_sources:
+  - pypi:
+      identifier: lightgbm

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,14 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set CUDA_ARGS=
+if "%gpu_variant%"=="cuda" (
+    set "CUDA_ARGS=-Ccmake.define.USE_CUDA=ON"
+    set CUDA_HOME=%BUILD_PREFIX%\Library
+    set CUDA_PATH=%BUILD_PREFIX%\Library
+)
+
+%PYTHON% -m pip install . --no-deps --no-build-isolation -vv ^
+    -Ccmake.define.CMAKE_GENERATOR="Visual Studio 17 2022" ^
+    %CUDA_ARGS%
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -exo pipefail
+
+CUDA_ARGS=""
+if [[ "${gpu_variant}" == "cuda" ]]; then
+    CUDA_ARGS="-Ccmake.define.USE_CUDA=ON"
+fi
+
+${PYTHON} -m pip install . --no-deps --no-build-isolation -vv \
+    -Ccmake.define.CMAKE_GENERATOR="Ninja" \
+    ${CUDA_ARGS}

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+c_compiler:                    # [win]
+- vs2019                       # [win]
+cxx_compiler:                  # [win]
+- vs2019                       # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,4 @@
-c_compiler:                    # [win]
-- vs2019                       # [win]
-cxx_compiler:                  # [win]
-- vs2019                       # [win]
+c_compiler:                      # [win]
+  - vs2019                       # [win]
+cxx_compiler:                    # [win]
+  - vs2019                       # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,29 @@
+# Repeated to match gpu_variant zip_keys (none, cuda, cuda)
 c_compiler:                      # [win]
-  - vs2019                       # [win]
+  - vs2022                       # [win]
+  - vs2022                       # [win]
+  - vs2022                       # [win]
 cxx_compiler:                    # [win]
-  - vs2019                       # [win]
+  - vs2022                       # [win]
+  - vs2022                       # [win]
+  - vs2022                       # [win]
+
+gpu_variant:
+  - none
+  - cuda                         # [linux or win]
+  - cuda                         # [linux or win]
+
+cuda_compiler:                   # [linux or win]
+  - cuda-nvcc                    # [linux or win]
+
+cuda_compiler_version:           # [linux or win]
+  - none                         # [linux or win]
+  - 12.9                         # [linux or win]
+  - 13.1                         # [linux or win]
+
+zip_keys:
+  -
+    - gpu_variant
+    - cuda_compiler_version      # [linux or win]
+    - c_compiler                 # [win]
+    - cxx_compiler               # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,9 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  missing_dso_whitelist:  # [s390x or osx]
+    - "*/ld64.so.1"       # [s390x]
+    - '*/libc++.1.dylib'  # [osx]
 
 requirements:
   build:
@@ -34,6 +37,7 @@ requirements:
     - numpy
     - scipy
     - scikit-learn !=0.22.0
+    - _openmp_mutex      # [linux]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lightgbm" %}
-{% set version = "4.5.0" %}
+{% set version = "4.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,9 +7,9 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: e1cd7baf0318d4e308a26575a63a4635f08df866ad3622a9d8e3d71d9637a1ba
+    sha256: cb1c59720eb569389c0ba74d14f52351b573af489f230032a1c9f314f8bab7fe
   - url: https://github.com/microsoft/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: cc72ae1f979935e11243c93bacefe34144a4fcf3dc304b2a53d99ea408fe8976
+    sha256: 71d2c25855f10e82da8cb8b0c42bdf0da56e5556ff50a93b31c0592b8932eda3
     folder: tests
 
 build:
@@ -26,14 +26,14 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake >=3.18
-      # We currently don't have ninja 1.11, which upstream specifies. 
+      # We currently don't have ninja 1.11, which upstream specifies.
       # However, this feedstock builds and passes tests with v1.10.2
     - ninja >=1.10.2  # [unix]
   host:
-    # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy) 
-    # that was built with openblas rather than mkl. Openblas typically pairs with llvm-openmp and mkl with intel-openmp on osx-64. 
-    # By default, mkl variants are picked. By picking the variant that uses openblas rather 
-    # than mkl, intel-openmp will not be pulled in and so you will not have llvm-openmp / intel-openmp conflict. 
+    # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy)
+    # that was built with openblas rather than mkl. Openblas typically pairs with llvm-openmp and mkl with intel-openmp on osx-64.
+    # By default, mkl variants are picked. By picking the variant that uses openblas rather
+    # than mkl, intel-openmp will not be pulled in and so you will not have llvm-openmp / intel-openmp conflict.
     - blas =*=openblas  # [osx and x86_64]
     - scikit-build-core >=0.9.3
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,6 @@ requirements:
     - scikit-build-core >=0.4.4
     - python
     - pip
-    - setuptools
-    - wheel
     - llvm-openmp  # [osx]
     - libgomp      # [linux]
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,14 +23,20 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
+    # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy) 
+    # that was built with openblas rather than mkl. Openblas typically pairs with llvm-openmp and mkl with intel-openmp on osx-64. 
+    # By default, mkl variants are picked. By picking the variant that uses openblas rather 
+    # than mkl, intel-openmp will not be pulled in and so you will not have llvm-openmp / intel-openmp conflict. 
+    - blas=*=openblas # [osx and x86_64]
     - scikit-build-core >=0.4.4
     - python
     - pip
     - setuptools
     - wheel
     - llvm-openmp  # [osx]
-    - libgomp  # [linux]
+    - libgomp      # [linux]
   run:
+    - blas=*=openblas # [osx and x86_64]  
     - python
     - numpy
     - scipy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lightgbm" %}
-{% set version = "4.3.0" %}
+{% set version = "4.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 006f5784a9bcee43e5a7e943dc4f02de1ba2ee7a7af1ee5f190d383f3b6c9ebe
+  sha256: 9e8a7640911481134e60987d5d1e1cd157f430c3b4b38de8d36fc55c302bc299
 
 build:
   number: 0
@@ -30,7 +30,7 @@ requirements:
     # By default, mkl variants are picked. By picking the variant that uses openblas rather 
     # than mkl, intel-openmp will not be pulled in and so you will not have llvm-openmp / intel-openmp conflict. 
     - blas=*=openblas  # [osx and x86_64]
-    - scikit-build-core >=0.4.4
+    - scikit-build-core >=0.9.3
     - python
     - pip
     - llvm-openmp      # [osx]
@@ -39,8 +39,9 @@ requirements:
     - blas=*=openblas  # [osx and x86_64]
     - python
     - dataclasses      # [py<37]
-    - numpy
+    - numpy >=1.17.0
     - scipy
+    - typing_extensions
   run_constrained:
     - cffi >=1.15.1
     - dask >=2.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,12 +6,16 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9e8a7640911481134e60987d5d1e1cd157f430c3b4b38de8d36fc55c302bc299
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 9e8a7640911481134e60987d5d1e1cd157f430c3b4b38de8d36fc55c302bc299
+  - url: https://github.com/microsoft/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: 2633afd64f4f28c5563cb64e96adf8aa6fae58af11b13345166392fb05e56215
+    folder: tests
 
 build:
   number: 0
   skip: true  # [py<36]
+  script: ls
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Visual Studio 16 2019"  # [win]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Ninja" # [unix]
   missing_dso_whitelist:  # [s390x or osx]
@@ -50,13 +54,27 @@ requirements:
     - scikit-learn !=0.22.0
 
 test:
+  source_files:
+    - tests
   imports:
     - lightgbm
   requires:
     - pip
+    - matplotlib-base
+    - pytest
+    - cloudpickle
+    - psutil
+    # arrow
+    - pyarrow
+    - cffi
+    # panda
+    - pandas
+    # scikit-learn
     - scikit-learn
+
   commands:
     - pip check
+    - pytest -vv .
 
 about:
   home: https://github.com/Microsoft/LightGBM

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - dask >=2.0.0
     - pandas >=0.24.0
     - pyarrow >=6.0.1
-    - scikit-learn !=0.22.0
+    - scikit-learn >=0.24.2
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,14 +28,14 @@ requirements:
     - cmake >=3.18
       # We currently don't have ninja 1.11, which upstream specifies.
       # However, this feedstock builds and passes tests with v1.10.2
-    - ninja >=1.10.2  # [unix]
+    - ninja >=1.12.1  # [unix]
   host:
     # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy)
     # that was built with openblas rather than mkl. Openblas typically pairs with llvm-openmp and mkl with intel-openmp on osx-64.
     # By default, mkl variants are picked. By picking the variant that uses openblas rather
     # than mkl, intel-openmp will not be pulled in and so you will not have llvm-openmp / intel-openmp conflict.
     - blas =*=openblas  # [osx and x86_64]
-    - scikit-build-core >=0.9.3
+    - scikit-build-core >=0.10.1
     - python
     - pip
     - llvm-openmp      # [osx]
@@ -43,10 +43,8 @@ requirements:
     - _openmp_mutex    # [linux]
     - blas =*=openblas  # [osx and x86_64]
     - python
-    - dataclasses      # [py<37]
     - numpy >=1.17.0
     - scipy
-    - typing_extensions
   run_constrained:
     - cffi >=1.15.1
     - dask >=2.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,9 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  missing_dso_whitelist:  # [s390x or osx]
+    - "*/ld64.so.1"       # [s390x]
+    - '*/libc++.1.dylib'  # [osx]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lightgbm" %}
-{% set version = "4.1.0" %}
+{% set version = "4.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,43 +7,46 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bee59dd269a93b093f2c610d4a6683a7ea87c63d3ea35c622123ce2c020b2abc
+  sha256: 006f5784a9bcee43e5a7e943dc4f02de1ba2ee7a7af1ee5f190d383f3b6c9ebe
 
 build:
   number: 0
+  skip: true  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Visual Studio 16 2019"  # [win]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv  # [unix]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Ninja" # [unix]
   missing_dso_whitelist:  # [s390x or osx]
     - "*/ld64.so.1"       # [s390x]
     - '*/libc++.1.dylib'  # [osx]
 
 requirements:
   build:
-    - cmake >=3.8
-    - make                  # [unix]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - cmake >=3.8
+    - ninja
   host:
     # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy) 
     # that was built with openblas rather than mkl. Openblas typically pairs with llvm-openmp and mkl with intel-openmp on osx-64. 
     # By default, mkl variants are picked. By picking the variant that uses openblas rather 
     # than mkl, intel-openmp will not be pulled in and so you will not have llvm-openmp / intel-openmp conflict. 
-    - blas=*=openblas # [osx and x86_64]
+    - blas=*=openblas  # [osx and x86_64]
     - scikit-build-core >=0.4.4
     - python
     - pip
-    - llvm-openmp  # [osx]
-    - libgomp      # [linux]
+    - llvm-openmp      # [osx]
   run:
-    - blas=*=openblas # [osx and x86_64]  
+    - _openmp_mutex    # [linux]
+    - blas=*=openblas  # [osx and x86_64]
     - python
-    - dataclasses # [py<37]
+    - dataclasses      # [py<37]
     - numpy
     - scipy
-  run_constrained: 
-    - scikit-learn !=0.22.0
-    - pandas>=0.24.0
+  run_constrained:
+    - cffi >=1.15.1
     - dask >=2.0.0
+    - pandas >=0.24.0
+    - pyarrow >=6.0.1
+    - scikit-learn !=0.22.0
 
 test:
   imports:
@@ -61,7 +64,7 @@ about:
   license_file: LICENSE
   summary: LightGBM is a gradient boosting framework that uses tree based learning algorithms.
   description: |
-    A fast, distributed, high performance gradient boosting (GBDT, GBRT, GBM or MART) framework 
+    A fast, distributed, high performance gradient boosting (GBDT, GBRT, GBM or MART) framework
     based on decision tree algorithms, used for ranking, classification and many other machine learning tasks.
   doc_url: https://lightgbm.readthedocs.io
   dev_url: https://github.com/Microsoft/LightGBM

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,6 +53,11 @@ about:
   dev_url: https://github.com/Microsoft/LightGBM
 
 extra:
+
+  anaconda-services:
+    ref: https://anaconda.zendesk.com/agent/tickets/30613 
+    recipe-maintainers:
+      - ianaobi
   recipe-maintainers:
     - synapticarbors
     - aldanor

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,22 +1,20 @@
 {% set name = "lightgbm" %}
-{% set version = "3.3.5" %}
-{% set sha256 = "10b8fbdcf851e4f68a1f02f38d99bdc44c7c7fb9b1a62dcf924a0d29ff73395c" %}
+{% set version = "4.1.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: bee59dd269a93b093f2c610d4a6683a7ea87c63d3ea35c622123ce2c020b2abc
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
-  missing_dso_whitelist:  # [s390x or osx]
-    - "*/ld64.so.1"       # [s390x]
-    - '*/libc++.1.dylib'  # [osx]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  # missing_dso_whitelist:  # [s390x or osx]
+  #   - "*/ld64.so.1"       # [s390x]
+  #   - '*/libc++.1.dylib'  # [osx]
 
 requirements:
   build:
@@ -25,6 +23,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
+    - scikit-build-core >=0.4.4
     - python
     - pip
     - setuptools
@@ -36,8 +35,13 @@ requirements:
     - python
     - numpy
     - scipy
+    # - _openmp_mutex      # [linux]
+  run_constrained:
     - scikit-learn !=0.22.0
-    - _openmp_mutex      # [linux]
+    - pandas >=0.24.0
+    - pyarrow >=6.0.1
+    - cffi >=1.15.1
+    - dask >=2.0.0"
 
 test:
   imports:
@@ -54,12 +58,12 @@ about:
   license_file: LICENSE
   summary: LightGBM is a gradient boosting framework that uses tree based learning algorithms.
   description: |
-    A fast, distributed, high performance gradient boosting (GBDT, GBRT, GBM or MART) framework based on decision tree algorithms, used for ranking, classification and many other machine learning tasks.
+    A fast, distributed, high performance gradient boosting (GBDT, GBRT, GBM or MART) framework 
+    based on decision tree algorithms, used for ranking, classification and many other machine learning tasks.
   doc_url: https://lightgbm.readthedocs.io
   dev_url: https://github.com/Microsoft/LightGBM
 
 extra:
-
   anaconda-services:
     ref: https://anaconda.zendesk.com/agent/tickets/30613 
     recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake >=3.18
+      # We currently don't have ninja 1.11, which upstream specifies. 
+      # However, this feedstock builds and passes tests with v1.10.2
     - ninja >=1.10.2  # [unix]
   host:
     # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy) 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,7 +77,7 @@ test:
     - pip check
     # skipping tests on s390x due to the accuracy required for computational tests.
     - pytest -vv .  # [not s390x]
-    - pytest -vv -k "not (test_categorical_handle or test_categorical_handle_na or test_categorical_non_zero_inputs or test_contribs_sparse_multiclass or test_quantized_training)"  # [s390x]
+    - pytest -vv -k "not (test_categorical_handle or test_categorical_handle_na or test_categorical_non_zero_inputs or test_contribs_sparse_multiclass or test_quantized_training or test_contribs_sparse)"  # [s390x]
 
 about:
   home: https://github.com/Microsoft/LightGBM

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lightgbm" %}
-{% set version = "4.4.0" %}
+{% set version = "4.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,14 +7,14 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 9e8a7640911481134e60987d5d1e1cd157f430c3b4b38de8d36fc55c302bc299
+    sha256: e1cd7baf0318d4e308a26575a63a4635f08df866ad3622a9d8e3d71d9637a1ba
   - url: https://github.com/microsoft/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 2633afd64f4f28c5563cb64e96adf8aa6fae58af11b13345166392fb05e56215
+    sha256: cc72ae1f979935e11243c93bacefe34144a4fcf3dc304b2a53d99ea408fe8976
     folder: tests
 
 build:
   number: 0
-  skip: true  # [py<36]
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Visual Studio 16 2019"  # [win]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Ninja" # [unix]
   missing_dso_whitelist:  # [s390x or osx]
@@ -34,14 +34,14 @@ requirements:
     # that was built with openblas rather than mkl. Openblas typically pairs with llvm-openmp and mkl with intel-openmp on osx-64. 
     # By default, mkl variants are picked. By picking the variant that uses openblas rather 
     # than mkl, intel-openmp will not be pulled in and so you will not have llvm-openmp / intel-openmp conflict. 
-    - blas=*=openblas  # [osx and x86_64]
+    - blas =*=openblas  # [osx and x86_64]
     - scikit-build-core >=0.9.3
     - python
     - pip
     - llvm-openmp      # [osx]
   run:
     - _openmp_mutex    # [linux]
-    - blas=*=openblas  # [osx and x86_64]
+    - blas =*=openblas  # [osx and x86_64]
     - python
     - dataclasses      # [py<37]
     - numpy >=1.17.0
@@ -65,6 +65,7 @@ test:
     - pytest
     - cloudpickle
     - psutil
+    - joblib >=1.3.2
     # arrow
     - pyarrow
     - cffi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv  -Ccmake.define.CMAKE_GENERATOR="Visual Studio 16 2019"
   missing_dso_whitelist:  # [s390x or osx]
     - "*/ld64.so.1"       # [s390x]
     - '*/libc++.1.dylib'  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake >=3.18
-    # we currently don't have ninja 1.11 but it's building and passing tests
-    - ninja >=1.10.2
+    - ninja >=1.10.2  # [unix]
   host:
     # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy) 
     # that was built with openblas rather than mkl. Openblas typically pairs with llvm-openmp and mkl with intel-openmp on osx-64. 
@@ -73,7 +72,7 @@ test:
     - scikit-learn
   commands:
     - pip check
-    # skipping tests for s390x due to assertion error: Not equal to tolerance rtol=1e-07, atol=0
+    # skipping tests on s390x due to the accuracy required for computational tests.
     - pytest -vv .  # [not s390x]
     - pytest -vv -k "not (test_categorical_handle or test_categorical_handle_na or test_categorical_non_zero_inputs or test_contribs_sparse_multiclass or test_quantized_training)"  # [s390x]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ source:
 build:
   number: 0
   skip: true  # [py<36]
-  script: ls
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Visual Studio 16 2019"  # [win]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Ninja" # [unix]
   missing_dso_whitelist:  # [s390x or osx]
@@ -26,8 +25,8 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - cmake >=3.8
-    - ninja
+    - cmake >=3.18
+    - ninja >= 1.11
   host:
     # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy) 
     # that was built with openblas rather than mkl. Openblas typically pairs with llvm-openmp and mkl with intel-openmp on osx-64. 
@@ -71,7 +70,6 @@ test:
     - pandas
     # scikit-learn
     - scikit-learn
-
   commands:
     - pip check
     - pytest -vv .  # [not s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,15 +39,20 @@ requirements:
   run:
     - blas=*=openblas # [osx and x86_64]  
     - python
+    - dataclasses # [py<37]
     - numpy
     - scipy
+  run_constrained: 
+    - scikit-learn !=0.22.0
+    - pandas>=0.24.0
+    - dask >=2.0.0
 
 test:
   imports:
     - lightgbm
   requires:
     - pip
-    - scikit-learn !=0.22.0
+    - scikit-learn
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "lightgbm" %}
-{% set version = "3.3.3" %}
-{% set sha256 = "857e559ae84a22963ce2b62168292969d21add30bc9246a84d4e7eedae67966d" %}
+{% set version = "3.3.5" %}
+{% set sha256 = "10b8fbdcf851e4f68a1f02f38d99bdc44c7c7fb9b1a62dcf924a0d29ff73395c" %}
 
 package:
   name: {{ name|lower }}
@@ -12,14 +12,11 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
-  skip: true  # [win32]
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - cmake >=3.8
     - make
     - {{ compiler('c') }}
@@ -28,8 +25,9 @@ requirements:
     - python
     - pip
     - setuptools
-    - llvm-openmp  # [osx]
-    - libgomp  # [linux]
+    - wheel
+    - llvm-openmp 14.0.6  # [osx]
+    - libgomp 11.2.0      # [linux]
   run:
     - python
     - numpy
@@ -39,6 +37,10 @@ requirements:
 test:
   imports:
     - lightgbm
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/Microsoft/LightGBM
@@ -46,10 +48,9 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: LightGBM is a gradient boosting framework that uses tree based learning algorithms.
-
   description: |
     A fast, distributed, high performance gradient boosting (GBDT, GBRT, GBM or MART) framework based on decision tree algorithms, used for ranking, classification and many other machine learning tasks.
-  doc_url: http://lightgbm.readthedocs.io/en/latest/
+  doc_url: https://lightgbm.readthedocs.io
   dev_url: https://github.com/Microsoft/LightGBM
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,6 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  # missing_dso_whitelist:  # [s390x or osx]
-  #   - "*/ld64.so.1"       # [s390x]
-  #   - '*/libc++.1.dylib'  # [osx]
 
 requirements:
   build:
@@ -28,26 +25,19 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - llvm-openmp 14.0.6  # [osx]
-    # libgomp pulled in through gcc setup
-    # - libgomp 11.2.0      # [linux]
+    - llvm-openmp  # [osx]
+    - libgomp  # [linux]
   run:
     - python
     - numpy
     - scipy
-    # - _openmp_mutex      # [linux]
-  run_constrained:
-    - scikit-learn !=0.22.0
-    - pandas >=0.24.0
-    - pyarrow >=6.0.1
-    - cffi >=1.15.1
-    - dask >=2.0.0"
 
 test:
   imports:
     - lightgbm
   requires:
     - pip
+    - scikit-learn !=0.22.0
   commands:
     - pip check
 
@@ -64,10 +54,6 @@ about:
   dev_url: https://github.com/Microsoft/LightGBM
 
 extra:
-  anaconda-services:
-    ref: https://anaconda.zendesk.com/agent/tickets/30613 
-    recipe-maintainers:
-      - ianaobi
   recipe-maintainers:
     - synapticarbors
     - aldanor

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,8 @@ requirements:
     - setuptools
     - wheel
     - llvm-openmp 14.0.6  # [osx]
-    - libgomp 11.2.0      # [linux]
+    # libgomp pulled in through gcc setup
+    # - libgomp 11.2.0      # [linux]
   run:
     - python
     - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ build:
 requirements:
   build:
     - cmake >=3.8
-    - make
+    - make                  # [unix]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,7 +75,7 @@ test:
   commands:
     - pip check
     - pytest -vv .  # [not s390x]
-    - pytest -vv -k "not (test_categorical_handle or test_categorical_handle_na or test_categorical_non_zero_inputs ortest_contribs_sparse_multiclass or test_quantized_training)"  # [s390x]
+    - pytest -vv -k "not (test_categorical_handle or test_categorical_handle_na or test_categorical_non_zero_inputs or test_contribs_sparse_multiclass or test_quantized_training)"  # [s390x]
 
 about:
   home: https://github.com/Microsoft/LightGBM

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake >=3.18
-    - ninja >= 1.11
+    # we currently don't have ninja 1.11 but it's building and passing tests
+    - ninja >=1.10.2
   host:
     # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy) 
     # that was built with openblas rather than mkl. Openblas typically pairs with llvm-openmp and mkl with intel-openmp on osx-64. 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,7 +74,8 @@ test:
 
   commands:
     - pip check
-    - pytest -vv .
+    - pytest -vv .  # [not s390x]
+    - pytest -vv -k "not (test_categorical_handle or test_categorical_handle_na or test_categorical_non_zero_inputs ortest_contribs_sparse_multiclass or test_quantized_training)"  # [s390x]
 
 about:
   home: https://github.com/Microsoft/LightGBM

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,6 +73,7 @@ test:
     - scikit-learn
   commands:
     - pip check
+    # skipping tests for s390x due to assertion error: Not equal to tolerance rtol=1e-07, atol=0
     - pytest -vv .  # [not s390x]
     - pytest -vv -k "not (test_categorical_handle or test_categorical_handle_na or test_categorical_non_zero_inputs or test_contribs_sparse_multiclass or test_quantized_training)"  # [s390x]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv  -Ccmake.define.CMAKE_GENERATOR="Visual Studio 16 2019"
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Visual Studio 16 2019"  # [win]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv  # [unix]
   missing_dso_whitelist:  # [s390x or osx]
     - "*/ld64.so.1"       # [s390x]
     - '*/libc++.1.dylib'  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,33 +1,44 @@
 {% set name = "lightgbm" %}
 {% set version = "4.6.0" %}
+{% set build_number = 0 %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
     sha256: cb1c59720eb569389c0ba74d14f52351b573af489f230032a1c9f314f8bab7fe
+    patches:
+      - patches/cuda13-compat.patch  # [gpu_variant == "cuda"]
   - url: https://github.com/microsoft/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
     sha256: 71d2c25855f10e82da8cb8b0c42bdf0da56e5556ff50a93b31c0592b8932eda3
     folder: tests
 
 build:
-  number: 0
-  skip: true  # [py<37]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Visual Studio 16 2019"  # [win]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Ninja" # [unix]
-  missing_dso_whitelist:  # [s390x or osx]
+  number: {{ build_number + 100 }}  # [gpu_variant == "cuda"]
+  number: {{ build_number }}        # [gpu_variant != "cuda"]
+  string: cuda{{ cuda_compiler_version | replace('.', '') }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
+  string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant != "cuda"]
+  skip: true  # [py<39]
+  script: build.sh   # [unix]
+  script: bld.bat    # [win]
+  # Suppress CUDA compiler run_exports (tight pin); use explicit cuda-version
+  # pin_compatible(min_pin='x') instead for forward compat within major version.
+  ignore_run_exports_from:                        # [gpu_variant == "cuda"]
+    - {{ compiler('cuda') }}                      # [gpu_variant == "cuda"]
+  missing_dso_whitelist:  # [s390x or osx or gpu_variant == "cuda"]
     - "*/ld64.so.1"       # [s390x]
     - '*/libc++.1.dylib'  # [osx]
+    - "**/libcuda.so*"    # [gpu_variant == "cuda"]
+    - "**/nvcuda.dll"     # [win and gpu_variant == "cuda"]
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ compiler('cuda') }}   # [gpu_variant == "cuda"]
     - cmake >=3.18
-      # We currently don't have ninja 1.11, which upstream specifies.
-      # However, this feedstock builds and passes tests with v1.10.2
     - ninja >=1.12.1  # [unix]
   host:
     # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy)
@@ -38,13 +49,17 @@ requirements:
     - scikit-build-core >=0.10.1
     - python
     - pip
-    - llvm-openmp      # [osx]
+    - llvm-openmp                                          # [osx]
+    - cuda-version {{ cuda_compiler_version }}              # [gpu_variant == "cuda"]
+    - cuda-cudart-dev                                      # [gpu_variant == "cuda"]
   run:
     - _openmp_mutex    # [linux]
     - blas =*=openblas  # [osx and x86_64]
     - python
     - numpy >=1.17.0
     - scipy
+    - {{ pin_compatible('cuda-version', min_pin='x') }}    # [gpu_variant == "cuda"]
+    - __cuda                                               # [gpu_variant == "cuda"]
   run_constrained:
     - cffi >=1.15.1
     - dask >=2.0.0
@@ -73,6 +88,10 @@ test:
     - scikit-learn
   commands:
     - pip check
+    - python -c "import lightgbm; print('LightGBM version:', lightgbm.__version__)"
+    # Verify shared library loads correctly (catches CUDA linkage issues)
+    - python -c "import ctypes, os, lightgbm; lib_path = os.path.join(os.path.dirname(lightgbm.__file__), 'lib_lightgbm.so'); ctypes.cdll.LoadLibrary(lib_path); print('Shared library loaded successfully')"  # [linux]
+    - python -c "import ctypes, os, lightgbm; lib_path = os.path.join(os.path.dirname(lightgbm.__file__), 'lib_lightgbm.dylib'); ctypes.cdll.LoadLibrary(lib_path); print('Shared library loaded successfully')"  # [osx]
     # skipping tests on s390x due to the accuracy required for computational tests.
     - pytest -vv .  # [not s390x]
     - pytest -vv -k "not (test_categorical_handle or test_categorical_handle_na or test_categorical_non_zero_inputs or test_contribs_sparse_multiclass or test_quantized_training or test_contribs_sparse)"  # [s390x]

--- a/recipe/patches/cuda13-compat.patch
+++ b/recipe/patches/cuda13-compat.patch
@@ -1,0 +1,25 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -219,7 +219,10 @@ endif()
+ if(USE_CUDA)
+     find_package(CUDAToolkit 11.0 REQUIRED)
+     include_directories(${CUDAToolkit_INCLUDE_DIRS})
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=${OpenMP_CXX_FLAGS} -Xcompiler=-fPIC -Xcompiler=-Wall")
++    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=${OpenMP_CXX_FLAGS}")
++    if(NOT MSVC)
++        set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=-fPIC -Xcompiler=-Wall")
++    endif()
+
+     # reference for mapping of CUDA toolkit component versions to supported architectures ("compute capabilities"):
+     # https://en.wikipedia.org/wiki/CUDA#GPUs_supported
+@@ -241,6 +244,10 @@ if(USE_CUDA)
+         list(APPEND CUDA_ARCHS "100")
+         list(APPEND CUDA_ARCHS "120")
+     endif()
++    if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "13.0")
++        # CUDA 13.x dropped support for compute capabilities < 7.5 (Maxwell, Pascal, Volta)
++        list(REMOVE_ITEM CUDA_ARCHS "60" "61" "62" "70")
++    endif()
+     # Generate PTX for the most recent architecture for forwards compatibility
+     list(POP_BACK CUDA_ARCHS CUDA_LAST_SUPPORTED_ARCH)
+     list(TRANSFORM CUDA_ARCHS APPEND "-real")

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -13,31 +13,61 @@ import unittest
 
 import lightgbm as lgb
 
-from sklearn.datasets import load_boston, load_breast_cancer
+from sklearn.datasets import load_breast_cancer, make_regression
 from sklearn.metrics import log_loss, mean_squared_error
 from sklearn.model_selection import train_test_split
+
+
+def make_synthetic_regression(
+    n_samples=100, n_features=4, n_informative=2, random_state=42
+):
+    return make_regression(
+        n_samples=n_samples,
+        n_features=n_features,
+        n_informative=n_informative,
+        random_state=random_state,
+    )
 
 
 class TestSklearn(unittest.TestCase):
     def test_binary(self):
         X, y = load_breast_cancer(return_X_y=True)
-        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
-        gbm = lgb.LGBMClassifier(n_estimators=50, silent=True)
-        gbm.fit(X_train, y_train, eval_set=[(X_test, y_test)], early_stopping_rounds=5, verbose=False)
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=0.1, random_state=42
+        )
+        gbm = lgb.LGBMClassifier(n_estimators=50, verbose=-1)
+        gbm.fit(
+            X_train,
+            y_train,
+            eval_set=[(X_test, y_test)],
+            callbacks=[lgb.early_stopping(5)],
+        )
         ret = log_loss(y_test, gbm.predict_proba(X_test))
-        self.assertLess(ret, 0.15)
-        self.assertAlmostEqual(ret, gbm.evals_result_['valid_0']['binary_logloss'][gbm.best_iteration_ - 1], places=5)
+        self.assertLess(ret, 0.12)
+        self.assertAlmostEqual(
+            ret,
+            gbm.evals_result_['valid_0']['binary_logloss'][gbm.best_iteration_ - 1],
+            places=5,
+        )
 
     def test_regression(self):
-        X, y = load_boston(return_X_y=True)
-        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
-        gbm = lgb.LGBMRegressor(n_estimators=50, silent=True)
-        gbm.fit(X_train, y_train, eval_set=[(X_test, y_test)], early_stopping_rounds=5, verbose=False)
+        X, y = make_synthetic_regression()
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=0.1, random_state=42
+        )
+        gbm = lgb.LGBMRegressor(n_estimators=50, verbose=-1)
+        gbm.fit(
+            X_train,
+            y_train,
+            eval_set=[(X_test, y_test)],
+            callbacks=[lgb.early_stopping(5)],
+        )
         ret = mean_squared_error(y_test, gbm.predict(X_test))
-        self.assertLess(ret, 16)
-        self.assertAlmostEqual(ret, gbm.evals_result_['valid_0']['l2'][gbm.best_iteration_ - 1], places=5)
+        self.assertLess(ret, 174)
+        self.assertAlmostEqual(
+            ret, gbm.evals_result_['valid_0']['l2'][gbm.best_iteration_ - 1], places=4
+        )
 
 
 if __name__ == '__main__':
-    if platform.machine() != "ppc64le":
-        unittest.main()
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add CUDA GPU variants (12.9 + 13.1) for LightGBM on linux-64, linux-aarch64, and win-64
- Upgrade Windows compiler from vs2019 to vs2022 (match aggregate default)
- Add `cuda13-compat.patch` to fix two upstream issues:
  - CUDA 13.x dropped SM < 7.5 (Maxwell, Pascal, Volta) but CMakeLists.txt still includes them
  - `-Xcompiler=-fPIC -Xcompiler=-Wall` are GCC flags that fail with MSVC on Windows
- Move inline build scripts to `build.sh`/`bld.bat` for CUDA conditional logic
- Add `__cuda` + `pin_compatible('cuda-version', min_pin='x')` in run deps per team convention
- Add shared library load test and version print test
- Fix source URL (`pypi.io` → `pypi.org`), tighten skip to `py<39`

## Build Matrix
| Platform | Variants |
|----------|----------|
| osx-64, osx-arm64 | CPU only × py39-py313 |
| linux-64, linux-aarch64 | CPU + CUDA 12.9 + CUDA 13.1 × py39-py313 |
| win-64 | CPU + CUDA 12.9 + CUDA 13.1 × py39-py313 |

## Patch Details
**`cuda13-compat.patch`** (quilt-verified, applies cleanly):
1. Guards `-Xcompiler=-fPIC -Xcompiler=-Wall` with `if(NOT MSVC)` — fixes Windows CUDA builds
2. Adds `list(REMOVE_ITEM CUDA_ARCHS "60" "61" "62" "70")` for CUDAToolkit >= 13.0 — nvcc 13.x dropped these architectures

## Test plan
- [ ] CPU variants build and pass tests on all platforms
- [ ] CUDA 12.9 variants build on linux-64, linux-aarch64, win-64
- [ ] CUDA 13.1 variants build on linux-64, linux-aarch64, win-64
- [ ] `pip check` passes for all variants
- [ ] Shared library load test passes (catches CUDA linkage issues)
- [ ] pytest suite passes on CPU variants

🤖 Generated with [Claude Code](https://claude.ai/claude-code)